### PR TITLE
Use full URL for filename, not just hostname.

### DIFF
--- a/httpscreenshot.py
+++ b/httpscreenshot.py
@@ -28,6 +28,10 @@ import signal
 import shutil
 import hashlib
 
+try:
+    from urllib.parse import quote
+except:
+    from urllib import quote
 
 reload(sys)
 sys.setdefaultencoding("utf8")
@@ -181,9 +185,10 @@ def worker(urlQueue, tout, debug, headless, doProfile, vhosts, subs, extraHosts,
 			except Queue.Empty:
 				continue
 			print '[+] '+str(urlQueue.qsize())+' URLs remaining'
-			screenshotName = urlparse(curUrl[0]).netloc.replace(":", "-")
+			screenshotName = quote(curUrl[0], safe='')
 			if(debug):
 				print '[+] Got URL: '+curUrl[0]
+				print '[+] screenshotName: '+screenshotName
 			if(os.path.exists(screenshotName+".png")):
 				if(debug):
 			 		print "[-] Screenshot already exists, skipping"

--- a/screenshotClustering/cluster.py
+++ b/screenshotClustering/cluster.py
@@ -8,6 +8,11 @@ import re
 import time
 from bs4 import BeautifulSoup
 
+try:
+    from urllib.parse import quote
+except:
+    from urllib import quote
+
 def addAttrToBag(attrName,url,link,wordBags,soup):
 	for tag in soup.findAll('',{attrName:True}):
 		if(isinstance(tag[attrName],str) or isinstance(tag[attrName],unicode)):
@@ -141,9 +146,11 @@ def renderClusterHtml(clust,width,height,scopeFile=None):
     
     for cluster,siteList in clust.iteritems():
         html=html+'<TR>'
-    	html=html+'<TR><TD><img src="'+siteList[0][0:-4]+'png" width='+str(width)+' height='+str(height)+'/></TD></TR>'
+        screenshotName = quote(siteList[0][0:-4], safe='')
+        html=html+'<TR><TD><img src="'+screenshotName+'png" width='+str(width)+' height='+str(height)+'/></TD></TR>'
         for site in siteList:
-            html=html+'<TD onmouseout="clearPopup()" onmouseover="popUp(event,\''+site[0:-4]+'png\');"><a href="'+site[0:-4]+'png">'+site[site.rfind('/')+1:site.rfind('-')]+':'+site[site.rfind('-')+1:site.rfind('.')]+'</a></TD>'
+            screenshotName = quote(site[0:-4], safe='')
+            html=html+'<TD onmouseout="clearPopup()" onmouseover="popUp(event,\''+screenshotName+'png\');"><a href="'+screenshotName+'png">'+site[site.rfind('/')+1:site.rfind('-')]+':'+site[site.rfind('-')+1:site.rfind('.')]+'</a></TD>'
         html=html+'</TR>'
     html=html+'</table>'
     footer = '</BODY></HTML>'


### PR DESCRIPTION
This allows for separate filenames for http://foo.com/,
https://foo.com/, https://joe:user@foo.com/, http://foo.com/path1/,
http://foo.com/path2/.  I wanted to be able to compare /asdf/ from
a bunch of servers, or compare screenshots when different basic-auth
credentials had been used when fetching.

This implementation simply URL-quotes the entire URL, which results
in a messy, but filesystem-safe name.  It might be desirable to be
a bit more selective to make the filename less ugly.

Should be both python2 and python3 safe.