### PR TITLE
Add switch to cli to allow choice between Chrome/Firefox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ RUN ln -s /etc/httpscreenshot/httpscreenshot.py /usr/bin/httpscreenshot
 
 RUN mkdir -p /etc/httpscreenshot/images
 WORKDIR /etc/httpscreenshot/images
+
+ENTRYPOINT ["httpscreenshot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# docker pull andmyhacks/httpscreenshot
+# docker pull jesse-osiecki/httpscreenshot
 
 FROM ubuntu:20.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# docker pull jesse-osiecki/httpscreenshot
+# docker pull jesseosiecki/httpscreenshot
 
 FROM ubuntu:20.04
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # httpscreenshot
 
+### Installation via Docker
+
+`docker pull jesseosiecki/httpscreenshot`
+`docker run -v 
+
 ### Installation on Ubuntu
 
 #### Via Script
 
 Run `install-dependencies.sh` script as root.
 
-This script has been tested on Ubuntu 14.04.
+This script has been tested on Ubuntu 20.04 as *root* (sudo).
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Installation via Docker
 
 `docker pull jesseosiecki/httpscreenshot`
-`docker run -v 
+`docker run jesseosiecki/httpscreenshot`
 
 ### Installation on Ubuntu
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,4 +1,4 @@
-# Installation Script - tested on a fresh install of Ubuntu 20.04.3 LTS
+# Installation Script - tested on a fresh install of Ubuntu 20.04.3 LTS as root (sudo)
 
 # Show all commands being run
 #set -x
@@ -7,11 +7,11 @@
 set -e
 
 # Pull packages from apt
-sudo apt install -y python3-pip build-essential libssl-dev swig python3-dev
+apt install -y python3-pip build-essential libssl-dev swig python3-dev
 
 # Install Google Chrome
 wget -O /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo apt install -y /tmp/google-chrome-stable_current_amd64.deb
+apt install -y /tmp/google-chrome-stable_current_amd64.deb
 
 # Install required python packages
 pip3 install -r requirements.txt


### PR DESCRIPTION
  - Add switch to cli to allow choice between Chrome/Firefox, keeping the -p headless flag as an option for both
  - Default is Firefox as the previous changes defaulting to Chrome breaks previous functionality, Docker image doesn't have Chrome
  - the install script is used by the Docker image, which doesn't have sudo. I propose reverting the addition of `sudo` within the script, and rather added verbiage to the README and script to run it with `sudo`